### PR TITLE
Only append a newline to the log when adding stacktrace info.

### DIFF
--- a/UberLoggerFile.cs
+++ b/UberLoggerFile.cs
@@ -37,8 +37,8 @@ public class UberLoggerFile : UberLogger.ILogger
                 {
                     LogLineToFile(frame.GetFormattedMethodName());
                 }
+                LogLineToFile("\n");
             }
-            LogLineToFile("\n");
         }
     }
 


### PR DESCRIPTION
This single change only appends the additional new line when the call stack is present. This keeps logs without trace info compact.
